### PR TITLE
fix: hasMatchingCredentials return null when no match

### DIFF
--- a/app/coreAPI.server.ts
+++ b/app/coreAPI.server.ts
@@ -155,7 +155,7 @@ export const hasMatchingCredentials = async (
 
     logger.info(`Has matching credentials? ${result.match}.`);
 
-    return result.url;
+    return result.match ? result.url : null;
   } catch (e) {
     logger.error(`hasMatchingCredentials for ${email} failed. Error: ${e}`);
     throw e;


### PR DESCRIPTION
## Summary
Fix bug where hasMatchingCredentials in coreAPI returns a request url instead of null when no matching credentials are found.