### PR TITLE
feat: set fullname credential as session identifier

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -9,7 +9,7 @@ import { ActionFunction, json, LoaderFunction } from '@remix-run/node';
 import { Form } from '@remix-run/react';
 import IconBoxAndLabel from '~/components/IconBoxAndLabel';
 import SpendSummary from '~/components/SpendSummary';
-import { logout, requireUserEmail } from '~/session.server';
+import { logout, requireUserName } from '~/session.server';
 
 // The exported `action` function will be called when the route makes a POST request, i.e. when the form is submitted.
 export const action: ActionFunction = async ({ request }) => {
@@ -19,10 +19,10 @@ export const action: ActionFunction = async ({ request }) => {
 // The exported `loader` function will be called when the route makes a GET request, i.e. when it is rendered
 export const loader: LoaderFunction = async ({ request }) => {
   // requireUser will redirect to the login page if the user is not logged in
-  const email = await requireUserEmail(request);
+  const name = await requireUserName(request);
 
   // return the user to the route, so it can be displayed
-  return json({ email });
+  return json({ name });
 };
 
 export default function Index() {

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -109,8 +109,17 @@ export const loader: LoaderFunction = async ({ request }) => {
   if (sharedCredentialsUuid) {
     const result = await sharedCredentials(sharedCredentialsUuid);
     if (result) {
-      const { email } = result;
-      return createUserSession(request, String(email), '/verified');
+      const { credentials } = result;
+      const fullNameCredential = credentials.find(
+        (credential) => credential.type === 'FullNameCredential'
+      ) as any;
+      if (!fullNameCredential) {
+        throw new Error('FullNameCredential is missing');
+      }
+      const fullName = fullNameCredential.data
+        .map((credential: any) => Object.values(credential.data)[0])
+        .join(' ');
+      return createUserSession(request, String(fullName), '/verified');
     }
   }
 

--- a/app/routes/verified.tsx
+++ b/app/routes/verified.tsx
@@ -8,7 +8,7 @@ import {
 } from '@remix-run/node';
 import { Form, useLoaderData } from '@remix-run/react';
 
-import { requireUserEmail } from '~/session.server';
+import { requireUserName } from '~/session.server';
 import VerifiedImage from '~/images/verified.png';
 
 // The exported `action` function will be called when the route makes a POST request, i.e. when the form is submitted.
@@ -19,14 +19,14 @@ export const action: ActionFunction = async ({ request }) => {
 // The exported `loader` function will be called when the route makes a GET request, i.e. when it is rendered
 export const loader: LoaderFunction = async ({ request }) => {
   // requireUserEmail will redirect to the login page if the user is not logged in
-  const email = await requireUserEmail(request);
+  const name = await requireUserName(request);
 
   // return the user to the route, so it can be displayed
-  return json({ email });
+  return json({ name });
 };
 
 export default function Verified() {
-  const { email } = useLoaderData<typeof loader>();
+  const { name } = useLoaderData<typeof loader>();
 
   return (
     <Box display='flex' flexDirection='column' alignItems='center'>
@@ -37,7 +37,7 @@ export default function Verified() {
       />
       <Typography variant='h1' align='center' mt={5}>
         {' '}
-        You're Verified, {email.split('@')[0]}!
+        You're Verified, {name}!
       </Typography>
       <Form method='post'>
         <Button>Go to Home</Button>

--- a/app/session.server.ts
+++ b/app/session.server.ts
@@ -21,8 +21,8 @@ export const sessionStorage = createCookieSessionStorage({
   },
 });
 
-// key for getting/setting the user email in the session
-const USER_SESSION_KEY = 'userEmail';
+// key for getting/setting the user name in the session
+const USER_SESSION_KEY = 'userName';
 
 /**
  * Gets the session from the request
@@ -39,12 +39,10 @@ export const getSession = async (request: Request) => {
  * @param {Request} request
  * @returns {Promise<string | null>} user
  */
-export const getUserEmail = async (
-  request: Request
-): Promise<string | null> => {
+export const getUserName = async (request: Request): Promise<string | null> => {
   const session = await getSession(request);
-  const email = session.get(USER_SESSION_KEY);
-  return email;
+  const name = session.get(USER_SESSION_KEY);
+  return name;
 };
 
 /**
@@ -64,15 +62,15 @@ export const logout = async (request: Request) => {
 };
 
 /**
- * Requires an authenticated user w/ email to be in the session for a request
+ * Requires an authenticated user w/ name to be in the session for a request
  * logs out if no user is found
  * @param {Request} request
- * @returns {Promise<string>} email
+ * @returns {Promise<string>} name
  */
-export const requireUserEmail = async (request: Request): Promise<string> => {
-  const email = await getUserEmail(request);
+export const requireUserName = async (request: Request): Promise<string> => {
+  const name = await getUserName(request);
 
-  if (email) return email;
+  if (name) return name;
 
   throw await logout(request);
 };
@@ -84,11 +82,11 @@ export const requireUserEmail = async (request: Request): Promise<string> => {
  */
 export const createUserSession = async (
   request: Request,
-  email: string,
+  name: string,
   redirectTo = '/'
 ) => {
   const session = await getSession(request);
-  session.set(USER_SESSION_KEY, email);
+  session.set(USER_SESSION_KEY, name);
   return redirect(redirectTo, {
     headers: {
       'Set-Cookie': await sessionStorage.commitSession(session),


### PR DESCRIPTION
[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work. There should _usually_ be a 1:1 relationship between a ticket and a PR, but that won't always be the case, so you may link the same ticket to multiple PRs, or add additional ticket links to this PR. If there is no ticket, you should probably create one and use the "added after sprint planning" label,
--->

## Summary
Uses full name instead of email when a user has finished the 1CS.

## Changes
- replaced email by full name credential

## Testing
Tested locally.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects