### PR TITLE
feat: add redirect to url and request 1-click with code only

### DIFF
--- a/app/coreAPI.server.ts
+++ b/app/coreAPI.server.ts
@@ -30,6 +30,7 @@ export interface OneClickOptions {
     description?: string;
   };
   credentialRequests?: CredentialRequest[]; // Encodes which credentials are being asked for 1-click
+  verificationOptions?: 'only_link' | 'only_code' | 'both_link_and_code';
 }
 
 /**
@@ -239,12 +240,16 @@ export const sharedCredentials = async (uuid: string) => {
  * Documentation: https://docs.unumid.co/api-overview#one-click
 
  * @param phone
- * @returns {Promise<{string | null}>} Returns an url that leads to 1-click signup request page
+ * @returns {Promise<{ url: string; phone: string }>} Returns an url that leads to 1-click signup request page
  */
 export const oneClick = async (
-  phone?: string
-): Promise<{ url: string; phone: string } | null> => {
-  if (!phone) return null; // short circuit if phone are not provided
+  phone?: string,
+  oneClickOptions?: Partial<OneClickOptions>
+): Promise<{ url: string; phone: string }> => {
+  // short circuit if phone are not provided
+  if (!phone) {
+    throw new Error('Phone was not provided');
+  }
 
   const headers = {
     Authorization: 'Bearer ' + config.unumAPIKey,
@@ -257,6 +262,7 @@ export const oneClick = async (
       title: 'Signup',
       description: 'Make sure everything is correct: ',
     },
+    ...oneClickOptions,
   };
 
   if (phone) options.phone = phone?.startsWith('+1') ? phone : '+1' + phone;

--- a/app/features/register/components/OneClickForm.tsx
+++ b/app/features/register/components/OneClickForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Link, useFetcher } from '@remix-run/react';
+import { Link, useFetcher, useSearchParams } from '@remix-run/react';
 import {
   Box,
   Button,
@@ -21,6 +21,9 @@ export function OneClickForm() {
   const [value, setValue] = useState<string>('');
   const [touched, setTouched] = useState<boolean>(false);
   const [count, setCount] = useState<number>(0);
+
+  const [searchParams] = useSearchParams();
+  const isRedirect = searchParams.get('redirect') === 'true';
 
   const validation = phoneSchema.safeParse(value);
   const errorMessage = !validation.success
@@ -138,7 +141,7 @@ export function OneClickForm() {
         </Link>
         .
       </Typography>
-      <Dialog open={isSuccess}>
+      <Dialog open={!isRedirect && isSuccess}>
         <DialogContent>
           <Typography fontWeight={700} textAlign='center'>
             Please click the verification link we just texted to <br />


### PR DESCRIPTION
[Ticket](https://trello.com/c/xWBKMskT/6546-clone-current-kredita-1-click-signup-demo-which-shows-the-without-redirect-flow-to-show-the-with-redirect-flow)
<!---
Link to the Trello ticket for this work. There should _usually_ be a 1:1 relationship between a ticket and a PR, but that won't always be the case, so you may link the same ticket to multiple PRs, or add additional ticket links to this PR. If there is no ticket, you should probably create one and use the "added after sprint planning" label,
--->

## Summary
Allow to redirect after phone form submission using query param.

## Changes
- updated service call
- updated register page and action

## Testing
Tested locally both normal flow and redirection flow.

## Video


https://github.com/VerifiedInc/Kredita-Demo-Web/assets/13892132/df8e43a2-007f-4fda-acde-2a0cdb039f41



## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects