### PR TITLE
chore: persist brand uuid with redirect url

### DIFF
--- a/app/coreAPI.server.ts
+++ b/app/coreAPI.server.ts
@@ -33,6 +33,7 @@ export interface OneClickOptions {
   };
   credentialRequests?: CredentialRequest[]; // Encodes which credentials are being asked for 1-click
   verificationOptions?: 'only_link' | 'only_code' | 'both_link_and_code';
+  redirectUrl?: string;
 }
 
 /**
@@ -243,9 +244,12 @@ export const sharedCredentials = async (uuid: string) => {
  * @param uuid
  * @returns {Promise<OneClickDto | null>} if a match for the request is found, returns the shared credentials, if no match is found returns null
  */
-export const getSharedCredentialsOneClick = async (uuid: string) => {
+export const getSharedCredentialsOneClick = async (
+  apiKey: string,
+  uuid: string
+) => {
   const headers = {
-    Authorization: 'Bearer ' + config.verifiedApiKey,
+    Authorization: 'Bearer ' + apiKey,
     'Content-Type': 'application/json',
   };
 

--- a/app/features/logout/usecases/logoutUseCase.ts
+++ b/app/features/logout/usecases/logoutUseCase.ts
@@ -1,0 +1,24 @@
+import { logout } from '~/session.server';
+
+export const logoutUseCase = async ({ request }: { request: Request }) => {
+  const url = new URL(request.url);
+  const searchParams = new URLSearchParams(url.searchParams);
+  const formData = await request.clone().formData();
+  const hasRedirectParam = formData.get('redirect') === 'true';
+
+  searchParams.delete('1ClickUuid');
+  searchParams.delete('sharedCredentialsUuid');
+
+  if (hasRedirectParam) {
+    searchParams.set('redirect', 'true');
+  }
+
+  const searchParamsString = searchParams.toString();
+
+  return logout(
+    request,
+    hasRedirectParam
+      ? `/register${searchParamsString ? `?${searchParamsString}` : ''}`
+      : undefined
+  );
+};

--- a/app/features/register/components/OneClickForm.tsx
+++ b/app/features/register/components/OneClickForm.tsx
@@ -45,6 +45,8 @@ export function OneClickForm() {
 
   const formRef = useRef<HTMLFormElement | null>(null);
 
+  const redirectUrl = typeof window !== 'undefined' ? window.location.href : '';
+
   const handlePhoneChange = (value: string) => {
     setValue(value);
     setTouched(true);
@@ -111,6 +113,7 @@ export function OneClickForm() {
         >
           <input name='action' value='one-click' hidden readOnly />
           <input name='apiKey' value={brand.apiKey} hidden readOnly />
+          <input name='redirectUrl' value={redirectUrl} hidden readOnly />
           <PhoneInput
             name='phone'
             autoFocus

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -9,16 +9,13 @@ import { ActionFunction, json, LoaderFunction } from '@remix-run/node';
 import { Form } from '@remix-run/react';
 import IconBoxAndLabel from '~/components/IconBoxAndLabel';
 import SpendSummary from '~/components/SpendSummary';
-import { logout, requireUserName } from '~/session.server';
+import { requireUserName } from '~/session.server';
+
+import { logoutUseCase } from '~/features/logout/usecases/logoutUseCase';
 
 // The exported `action` function will be called when the route makes a POST request, i.e. when the form is submitted.
 export const action: ActionFunction = async ({ request }) => {
-  const formData = await request.formData();
-  const hasRedirectParam = formData.get('redirect') === 'true';
-  return logout(
-    request,
-    hasRedirectParam ? '/register?redirect=true' : undefined
-  );
+  return logoutUseCase({ request });
 };
 
 // The exported `loader` function will be called when the route makes a GET request, i.e. when it is rendered

--- a/app/routes/verified.tsx
+++ b/app/routes/verified.tsx
@@ -12,22 +12,22 @@ import { logout, requireUserName } from '~/session.server';
 
 import { VerifiedImage } from '~/components/VerifiedImage';
 import { useBrand } from '~/hooks/useBrand';
+import { logoutUseCase } from '~/features/logout/usecases/logoutUseCase';
 
 // The exported `action` function will be called when the route makes a POST request, i.e. when the form is submitted.
 export const action: ActionFunction = async ({ request }) => {
+  const url = new URL(request.url);
+  const searchParams = new URLSearchParams(url.searchParams);
   const formData = await request.formData();
   const action = formData.get('action');
-  const hasRedirectParam = formData.get('redirect') === 'true';
 
   switch (action) {
     case 'logout': {
-      return logout(
-        request,
-        hasRedirectParam ? '/register?redirect=true' : undefined
-      );
+      return logoutUseCase({ request });
     }
     default: {
-      return redirect('/');
+      const searchParamsString = searchParams.toString();
+      return redirect(`/${searchParamsString ? `?${searchParamsString}` : ''}`);
     }
   }
 };

--- a/app/utils/getBrandSet.ts
+++ b/app/utils/getBrandSet.ts
@@ -1,0 +1,35 @@
+import { BrandDto } from '@verifiedinc/core-types';
+
+import { config } from '~/config';
+import { getBrandApiKey, getBrandDto } from '~/coreAPI.server';
+
+import { getBrand } from './getBrand';
+
+export const getBrandSet = async (searchParams: URLSearchParams) => {
+  let brand = getBrand(null);
+  let apiKey = config.verifiedApiKey;
+
+  // Allow custom branding under environment flag.
+  if (config.customBrandingEnabled) {
+    const brandUuid = searchParams.get('brand');
+
+    // Override possibly brand in session if query param is set.
+    if (brandUuid) {
+      apiKey = await getBrandApiKey(brandUuid, config.coreServiceAdminAuthKey);
+
+      brand = getBrand(
+        brandUuid
+          ? ((await getBrandDto(
+              brandUuid,
+              config.coreServiceAdminAuthKey
+            )) as BrandDto)
+          : null
+      );
+    }
+  }
+
+  return {
+    apiKey,
+    brand,
+  };
+};


### PR DESCRIPTION
[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work. There should _usually_ be a 1:1 relationship between a ticket and a PR, but that won't always be the case, so you may link the same ticket to multiple PRs, or add additional ticket links to this PR. If there is no ticket, you should probably create one and use the "added after sprint planning" label,
--->

## Summary
This PR handles the brand uuid and persists using a redirect URL of 1-click, it also persists the param through the dashboard.

## Changes
- updated verified page
- updated dashboard page
- updated register page

## Testing
Tested locally with brand and without brand.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects