### PR TITLE
chore: handle cancel use case

### DIFF
--- a/app/features/logout/usecases/logoutUseCase.ts
+++ b/app/features/logout/usecases/logoutUseCase.ts
@@ -1,9 +1,10 @@
 import { logout } from '~/session.server';
+import { getFormDataOrEmpty } from '~/utils/getFormDataOrEmpty.server';
 
 export const logoutUseCase = async ({ request }: { request: Request }) => {
   const url = new URL(request.url);
   const searchParams = new URLSearchParams(url.searchParams);
-  const formData = await request.clone().formData();
+  const formData = await getFormDataOrEmpty(request);
   const hasRedirectParam = formData.get('redirect') === 'true';
 
   searchParams.delete('1ClickUuid');
@@ -14,11 +15,7 @@ export const logoutUseCase = async ({ request }: { request: Request }) => {
   }
 
   const searchParamsString = searchParams.toString();
+  const search = searchParamsString ? `?${searchParamsString}` : '';
 
-  return logout(
-    request,
-    hasRedirectParam
-      ? `/register${searchParamsString ? `?${searchParamsString}` : ''}`
-      : undefined
-  );
+  return logout(request, `/register${search}`);
 };

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -25,6 +25,7 @@ import { OneClickForm } from '~/features/register/components/OneClickForm';
 import { LogInAndRegister } from '~/components/LoginAndRegister';
 import { useBrand } from '~/hooks/useBrand';
 import { getBrandSet } from '~/utils/getBrandSet';
+import { logoutUseCase } from '~/features/logout/usecases/logoutUseCase';
 
 // The exported `action` function will be called when the route makes a POST request, i.e. when the form is submitted.
 export const action: ActionFunction = async ({ request }) => {
@@ -141,9 +142,14 @@ export const loader: LoaderFunction = async ({ request }) => {
       oneClickUuid
     );
     if (result) {
+      const firstName = result?.credentials?.fullName?.firstName;
+
+      // Because the user has canceled 1-click flow, the credentials was not shared, so we need to logout the user.
+      if (!firstName) return logoutUseCase({ request });
+
       return createUserSession(
         request,
-        String(result.credentials.fullName.firstName),
+        String(firstName),
         `/verified?${searchParams.toString()}`
       );
     }

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -145,6 +145,7 @@ export const loader: LoaderFunction = async ({ request }) => {
       const firstName = result?.credentials?.fullName?.firstName;
 
       // Because the user has canceled 1-click flow, the credentials was not shared, so we need to logout the user.
+      // Customer Note: in a real implementation this ought to fall back to the standard sign up form.
       if (!firstName) return logoutUseCase({ request });
 
       return createUserSession(

--- a/app/utils/getFormDataOrEmpty.server.ts
+++ b/app/utils/getFormDataOrEmpty.server.ts
@@ -1,0 +1,11 @@
+import { logger } from '~/logger.server';
+
+export async function getFormDataOrEmpty(request: Request) {
+  try {
+    return await request.clone().formData();
+  } catch (error) {
+    logger.error('Error getting form data', error);
+  }
+
+  return new FormData();
+}


### PR DESCRIPTION
[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work. There should _usually_ be a 1:1 relationship between a ticket and a PR, but that won't always be the case, so you may link the same ticket to multiple PRs, or add additional ticket links to this PR. If there is no ticket, you should probably create one and use the "added after sprint planning" label,
--->

## Summary
Handles the 1-click cancel flow where the credentials are not shared, sending the user to the start flow of 1-click.

## Changes
- updated register loader
- added form data util

## Testing
Tested locally.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects