### PR TITLE
chore: control hosted/non-hosted by query param

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,6 @@ SENTRY_DSN=
 
 # 1 Click
 ONE_CLICK_ENABLED=false
-ONE_CLICK_NON_HOSTED_ENABLED=false
 
 # custom branding
 CUSTOM_BRANDING_ENABLED=false

--- a/app/config.client.ts
+++ b/app/config.client.ts
@@ -4,7 +4,6 @@ export interface BrowserConfig {
   sentryDSN: string;
   release: string;
   oneClickEnabled: boolean;
-  oneClickNonHostedEnabled: boolean;
   noticeEnabled: boolean;
   noticeText: string;
 }

--- a/app/config.ts
+++ b/app/config.ts
@@ -21,7 +21,6 @@ interface Config {
   demoUrl: string;
   sentryDSN: string;
   oneClickEnabled: boolean;
-  oneClickNonHostedEnabled: boolean;
   coreServiceAdminAuthKey: string;
   customBrandingEnabled: boolean;
   noticeEnabled: boolean;
@@ -46,9 +45,6 @@ export const config: Config = {
   demoUrl: process.env.DEMO_URL || '',
   sentryDSN: process.env.SENTRY_DSN || '',
   oneClickEnabled: Boolean(process.env.ONE_CLICK_ENABLED === 'true'),
-  oneClickNonHostedEnabled: Boolean(
-    process.env.ONE_CLICK_NON_HOSTED_ENABLED === 'true'
-  ),
   coreServiceAdminAuthKey: process.env.CORE_SERVICE_ADMIN_AUTH_KEY || '',
   customBrandingEnabled: Boolean(
     process.env.CUSTOM_BRANDING_ENABLED === 'true'

--- a/app/features/logout/usecases/logoutUseCase.ts
+++ b/app/features/logout/usecases/logoutUseCase.ts
@@ -1,11 +1,10 @@
 import { logout } from '~/session.server';
-import { getFormDataOrEmpty } from '~/utils/getFormDataOrEmpty.server';
 
 export const logoutUseCase = async ({ request }: { request: Request }) => {
   const url = new URL(request.url);
   const searchParams = new URLSearchParams(url.searchParams);
-  const formData = await getFormDataOrEmpty(request);
-  const verificationOptions = formData.get('verificationOptions');
+  const verificationOptions = searchParams.get('verificationOptions');
+  const isHosted = searchParams.get('isHosted');
 
   searchParams.delete('1ClickUuid');
   searchParams.delete('sharedCredentialsUuid');
@@ -13,6 +12,10 @@ export const logoutUseCase = async ({ request }: { request: Request }) => {
 
   if (verificationOptions) {
     searchParams.set('verificationOptions', String(verificationOptions));
+  }
+
+  if (isHosted) {
+    searchParams.set('isHosted', String(isHosted));
   }
 
   const searchParamsString = searchParams.toString();

--- a/app/hooks/useIsOneClickNonHosted.ts
+++ b/app/hooks/useIsOneClickNonHosted.ts
@@ -1,10 +1,10 @@
+import { useSearchParams } from '@remix-run/react';
 import { useAppContext } from '~/context/AppContext';
 
 // Returns true if one-click and non-hosted is enabled
 export function useIsOneClickNonHosted() {
+  const [searchParams] = useSearchParams();
+  const isHosted = searchParams.get('isHosted') !== 'false' ?? true;
   const appContext = useAppContext();
-  return (
-    appContext.config.oneClickEnabled &&
-    appContext.config.oneClickNonHostedEnabled
-  );
+  return appContext.config.oneClickEnabled && !isHosted;
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -80,7 +80,6 @@ export const loader: LoaderFunction = async ({ context, request }) => {
     sentryDSN,
     COMMIT_SHA,
     oneClickEnabled,
-    oneClickNonHostedEnabled,
     noticeEnabled,
     noticeText,
   } = config;
@@ -96,7 +95,6 @@ export const loader: LoaderFunction = async ({ context, request }) => {
       sentryDSN,
       release: COMMIT_SHA,
       oneClickEnabled,
-      oneClickNonHostedEnabled,
       noticeEnabled,
       noticeText,
     },

--- a/app/routes/personal-information.tsx
+++ b/app/routes/personal-information.tsx
@@ -69,6 +69,7 @@ export default function PersonalInformation() {
     );
     const optedOut = url.searchParams.get('optedOut');
     const verificationOptions = url.searchParams.get('verificationOptions');
+    const isHosted = url.searchParams.get('isHosted');
 
     _redirectUrl.searchParams.set('1ClickUuid', oneClickDB.uuid);
 
@@ -78,6 +79,10 @@ export default function PersonalInformation() {
 
     if (verificationOptions) {
       _redirectUrl.searchParams.set('verificationOptions', verificationOptions);
+    }
+
+    if (isHosted) {
+      _redirectUrl.searchParams.set('isHosted', isHosted);
     }
 
     return _redirectUrl.toString();


### PR DESCRIPTION
[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work. There should _usually_ be a 1:1 relationship between a ticket and a PR, but that won't always be the case, so you may link the same ticket to multiple PRs, or add additional ticket links to this PR. If there is no ticket, you should probably create one and use the "added after sprint planning" label,
--->

## Summary
Removed the environment usage to enable the non-hosted flavor of 1-click. Now, the `isHosted` URL query param should orchestrate that.

## Changes
- updated 1-click pages
- updated actions
- removed env

## Testing
Tested locally.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects